### PR TITLE
Force HSTS header always in Apache config

### DIFF
--- a/ssl-config-generator/index.html
+++ b/ssl-config-generator/index.html
@@ -169,7 +169,7 @@ frontend ft_test
                     }
                     if (data.hstsEnabled == "true") {
                         data.hsts = '\n    # HSTS' + '\n' +
-                            '    Header add Strict-Transport-Security "max-age=15768000"'
+                            '    Header always add Strict-Transport-Security "max-age=15768000"'
                     }
                     break;
                 case "haproxy":


### PR DESCRIPTION
Force to send the HSTS header on successful and unsucessful response.

If Apache returns a 404 or and redirect, the HSTS header is not sent back to the client. With the condition `always` [1] the HSTS header is always appended.

E.g without:

```
Header add Strict-Transport-Security "max-age=15768000"
RewriteEngine On
RewriteRule ^$ /foo [R=301,L]
```

Response:

```
$ wget --spider -S http://192.168.33.62/
Spider mode enabled. Check if remote file exists.
--2014-11-17 23:15:18--  http://192.168.33.62/
Connecting to 192.168.33.62:80... connected.
HTTP request sent, awaiting response... 
  HTTP/1.1 301 Moved Permanently
  Server: Apache/2.4.7 (Ubuntu)
  Location: http://192.168.33.62/foo
  Content-Type: text/html
Location: http://192.168.33.62/foo [following]
Spider mode enabled. Check if remote file exists.
--2014-11-17 23:15:18--  http://192.168.33.62/foo
Connecting to 192.168.33.62:80... connected.
HTTP request sent, awaiting response... 
  HTTP/1.1 404 Not Found
  Server: Apache/2.4.7 (Ubuntu)
  Content-Type: text/html
Remote file does not exist -- broken link!!!
```

E.g without `always`:

```
Header always add Strict-Transport-Security "max-age=15768000"
RewriteEngine On
RewriteRule ^$ /foo [R=301,L]
```

Response

```
$ wget --spider -S http://192.168.33.62/
Spider mode enabled. Check if remote file exists.
--2014-11-17 23:16:06--  http://192.168.33.62/
Connecting to 192.168.33.62:80... connected.
HTTP request sent, awaiting response... 
  HTTP/1.1 301 Moved Permanently
  Server: Apache/2.4.7 (Ubuntu)
  Strict-Transport-Security: max-age=15768000
  Location: http://192.168.33.62/foo
  Content-Type: text/html
Location: http://192.168.33.62/foo [following]
Spider mode enabled. Check if remote file exists.
--2014-11-17 23:16:06--  http://192.168.33.62/foo
Connecting to 192.168.33.62:80... connected.
HTTP request sent, awaiting response... 
  HTTP/1.1 404 Not Found
  Server: Apache/2.4.7 (Ubuntu)
  Strict-Transport-Security: max-age=15768000
  Content-Type: text/html
Remote file does not exist -- broken link!!!
```

[1] http://httpd.apache.org/docs/2.2/mod/mod_headers.html#header
