### PR TITLE
Bump maxDHKeySize to 2048 for intermediate profile

### DIFF
--- a/ssl-config-generator/index.html
+++ b/ssl-config-generator/index.html
@@ -203,7 +203,7 @@ frontend ft_test
                     haproxy: 'ssl no-sslv3'
                 },
                 clientList: 'Firefox 1, Chrome 1, IE 7, Opera 5, Safari 1, Windows XP IE8, Android 2.3, Java 7',
-                maxDHKeySize: '1024',
+                maxDHKeySize: '2048',
                 messages: []
             },
             old: {


### PR DESCRIPTION
In version 3.6 of the Server Side TLS document, the DH size in the intermediate was bumped to 2048 bits. With ECDHE available in the cipher list, even Java 7 should be able to connect. See https://wiki.mozilla.org/Security/Server_Side_TLS#DHE_and_Java for more information.
