### PR TITLE
Remove a dead in-page link for Nginx

### DIFF
--- a/Server_Side_TLS.mediawiki
+++ b/Server_Side_TLS.mediawiki
@@ -388,8 +388,6 @@ Try out our configuration generator to create a sample configuration file for va
 
 Nginx provides OCSP Stapling, custom DH parameters, and the full flavor of TLS versions (from OpenSSL).
 
-The detail of each configuration parameter, and how to build a recent Nginx with OpenSSL, is [[#Nginx_configuration_details|at the end of this document]].
-
 <pre>
 server {
     listen 443 ssl;


### PR DESCRIPTION
The additional information for Nginx was removed in
https://wiki.mozilla.org/index.php?title=Security/Server_Side_TLS&diff=990137&oldid=983316.
