### PR TITLE
Updated checking version of Apache and hide unsupported directive

### DIFF
--- a/ssl-config-generator/index.html
+++ b/ssl-config-generator/index.html
@@ -86,8 +86,8 @@ server {
     SSLProtocol             {{sslProtocols}}
     SSLCipherSuite          {{cipherSuites}}
     SSLHonorCipherOrder     on
-{{sslSessionTickets}}
 {{compression}}
+{{sslSessionTickets}}
 {{ocspStapling}}
 {{hsts}}
     ...
@@ -302,7 +302,11 @@ frontend ft_test
                     break;
                 case "apache":
                     // http://httpd.apache.org/docs/current/mod/mod_ssl.html
-                    data.compression = isSemVer(data.serverVersion, ">=2.4.3") ? '    SSLCompression          off' : '';
+                    if (isOpenSSLSemVer(data.opensslVersion, ">=0.9.8")) {
+                        if ((/^2\.2/.test(data.serverVersion) && isSemVer(data.serverVersion, '>=2.2.24')) || isSemVer(data.serverVersion, '>=2.4.3')) {
+                            data.compression = '    SSLCompression          off';
+                        }
+                    }
                     if (isOpenSSLSemVer(data.opensslVersion, ">=0.9.8h") && isSemVer(data.serverVersion, '>=2.3.3')) {
                         data.ocspStapling = '\n    # OCSP Stapling, only in httpd 2.3.3 and later' + '\n' +
                             '    SSLUseStapling          on' + '\n' +
@@ -311,8 +315,10 @@ frontend ft_test
                         data.ocspStaplingCache = 'SSLStaplingCache        shmcb:/var/run/ocsp(128000)' + '\n';
 
                     }
-                    if (isOpenSSLSemVer(data.opensslVersion, ">=0.9.8f") && isSemVer(data.serverVersion, '>=2.2.30')) {
-                        data.sslSessionTickets = '    SSLSessionTickets       off'
+                    if (isOpenSSLSemVer(data.opensslVersion, ">=0.9.8f")) {
+                        if ((/^2\.2/.test(data.serverVersion) && isSemVer(data.serverVersion, '>=2.2.30')) || isSemVer(data.serverVersion, '>=2.4.11')) {
+                            data.sslSessionTickets = '    SSLSessionTickets       off';
+                        }
                     }
                     if (isSemVer(data.serverVersion, '>=2.4.8')) {
                         data.certFile = '    SSLCertificateFile      /path/to/signed_certificate_followed_by_intermediate_certs';


### PR DESCRIPTION
In some version of Apache doesn't support SSLSessionTickets directive. So I updated checking version and hiding unsupported directive code.

In addition, also updated SSLCompression that require OpenSSL >= 0.9.8, and availability of Apache >= 2.2.24
