### PR TITLE
Move Apache server config outside VirtualHost

### DIFF
--- a/ssl-config-generator/index.html
+++ b/ssl-config-generator/index.html
@@ -82,16 +82,17 @@ server {
     SSLCertificateKeyFile   /path/to/private/key
     SSLCACertificateFile    /path/to/all_ca_certs
 
-    # {{securityProfile}} configuration, tweak to your needs
-    SSLProtocol             {{sslProtocols}}
-    SSLCipherSuite          {{cipherSuites}}
-    SSLHonorCipherOrder     on
-{{compression}}
-{{sslSessionTickets}}
-{{ocspStapling}}
 {{hsts}}
     ...
 &lt;/VirtualHost&gt;
+
+# {{securityProfile}} configuration, tweak to your needs
+SSLProtocol             {{sslProtocols}}
+SSLCipherSuite          {{cipherSuites}}
+SSLHonorCipherOrder     on
+{{compression}}
+{{sslSessionTickets}}
+{{ocspStapling}}
 {{ocspStaplingCache}}
 </pre>
     </script>


### PR DESCRIPTION
Rather than set the SSL default configuration inside of each virtual host, set it at the server level. Only virtual host specific customizations/overrides should be inside of the VirtualHost.

Thoughts?
