### PR TITLE
nginx: ssl_session_tickets appeared first in 1.5.9

### DIFF
--- a/ssl-config-generator/index.html
+++ b/ssl-config-generator/index.html
@@ -54,7 +54,7 @@ server {
     ssl_certificate_key /path/to/private_key;
     ssl_session_timeout 1d;
     ssl_session_cache shared:SSL:50m;
-    ssl_session_tickets off;
+{{sslSessionTickets}}
 {{dhparam}}
 
     # {{securityProfile}} configuration. tweak to your needs.
@@ -298,6 +298,9 @@ frontend ft_test
                     } else {
                         data.listen = '    listen 443;' + '\n' +
                             '    ssl on;';
+                    }
+                    if (isOpenSSLSemVer(data.opensslVersion, ">=0.9.8f") && isSemVer(data.serverVersion, '>=1.5.9')) {
+                        data.sslSessionTickets = '    ssl_session_tickets off;'
                     }
                     break;
                 case "apache":


### PR DESCRIPTION
See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_tickets

Also, replicate OpenSSL version constrain from 'case "apache"'.
