### PR TITLE
Trigger re-render on checkbox toggle

### DIFF
--- a/ssl-config-generator/index.html
+++ b/ssl-config-generator/index.html
@@ -554,6 +554,9 @@ $SERVER["socket"] == ":443" {
             $("input:radio").change(function() {
                 renderConfig(true);
             });
+            $("input:checkbox").change(function() {
+                renderConfig(false);
+            });
             $("input:text").change(function() {
                 renderConfig(false);
             });


### PR DESCRIPTION
Toggling HSTS checkbox didn't trigger configuration to be re-rendered.
