### PR TITLE
Better documentation of Apache OCSP directives.

### DIFF
--- a/Server_Side_TLS.mediawiki
+++ b/Server_Side_TLS.mediawiki
@@ -346,7 +346,26 @@ Before Apache 2.4.7, the DH parameter is always set to 1024 bits and is not user
 
     # OCSP Stapling, only in httpd 2.3.3 and later
     SSLUseStapling          on
-    SSLStaplingResponderTimeout 5
+    # Timeout in seconds when renewing queries for OCSP responders.
+    # Apache tries to connect to all available (IP) addresses in sequence
+    # until it succeeds. E.g., for an OCSP URI resolved to 2 IP addresses
+    # the total timeout is 2 seconds for an unresponsive responder.
+    # Setting the time to a small value does not keep the clients waiting
+    # during a renewal but requests may fail on a very slow connection to
+    # the OCSP responder.
+    SSLStaplingResponderTimeout 1
+    # When enabled, Apache will synthesize a "tryLater" response
+    # when it fails to elicit any response from the OCSP responder
+    # (See SSLStaplingResponderTimeout).
+    # Firefox 43 fails to connect with a sec_error_ocsp_try_server_later
+    # when security.OCSP.require is true.
+    # This fake response will be cached. Subsequent clients will receive
+    # this "tryLater" response if SSLStaplingReturnResponderErrors is on.
+    SSLStaplingFakeTryLater off
+    # When enabled, Apache will pass responses from unsuccessful stapling
+    # related OCSP queries on to the client. This includes fresh responses
+    # indicating anything but success and cached responses including fake
+    # "tryLater" ones originally created because of SSLStaplingFakeTryLater.
     SSLStaplingReturnResponderErrors off
     # On Apache 2.4+, SSLStaplingCache must be set *outside* of the VirtualHost
     SSLStaplingCache        shmcb:/var/run/ocsp(128000)


### PR DESCRIPTION
Went through the code in httpd-2.4.18 and realized that SSLStaplingResponderTimeout is a socket timeout applied to connect, send, recv and that mod_ssl will try each IP address of an OCSP responder in sequence. (modules/ssl/ssl_util_ocsp.c) The current 5 second timeout means up to 10 seconds of wait time for a web browser during an OCSP renewal where the DNS A record of the responder returns 2 IP addresses and the responder is unresponsive.

SSLStaplingFakeTryLater must also be off otherwise mod_ssl will return a fake "tryLater" response which causes Firefox to fail the connection with a sec_error_ocsp_try_server_later when security.OCSP.require is true. I think this was the default for earlier versions such as 38 but I haven't confirmed. In Firefox 43 I think this defaults to false. In any case it's a good idea not to return such fake responses since we are not returning any non-successful responses either.

Interestingly SSLStaplingFakeTryLater is relevant only during a renewal. After than the fake "tryLater" response is cached and is only returned if SSLStaplingReturnResponderErrors is on. So with the current configuration only unlucky clients who happen upon an OCSP response renewal will get this fake response and get confused.

Even with SSLStaplingFakeTryLater set to off the error.log file will erroneously print "stapling_renew_response: responder error" because logging happens before the check on whether to staple the fake response or not.
