### PR TITLE
Add nginx HTTPS redirect with HSTS, HTTP/2, and IPv6

### DIFF
--- a/ssl-config-generator/index.html
+++ b/ssl-config-generator/index.html
@@ -46,6 +46,16 @@
 <h2>{{server}} {{serverVersion}} | {{securityProfile}} profile | OpenSSL {{opensslVersion}} | <a href="?{{queryString}}">link</a></h2>
 <p>Oldest compatible clients : {{clientList}}</p>
 <pre>
+{{#if hstsEnabled}}
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    
+    # Redirect all HTTP requests to HTTPS with a 301 Moved Permanently response.
+    return 301 https://$host$request_uri;
+}
+
+{{/if}}
 server {
 {{listen}}
 
@@ -334,10 +344,15 @@ $SERVER["socket"] == ":443" {
                         data.hsts = '\n    # HSTS (ngx_http_headers_module is required) (15768000 seconds = 6 months)' + '\n' +
                             '    add_header Strict-Transport-Security max-age=15768000;';
                     }
-                    if (isSemVer(data.serverVersion, ">=0.7.14")) {
-                        data.listen = '    listen 443 ssl;';
+                    if (isSemVer(data.serverVersion, ">=1.9.5")) {
+                        data.listen = '    listen 443 ssl http2;\n' +
+                            '    listen [::]:443 ssl http2;';
+                    } else if (isSemVer(data.serverVersion, ">=0.7.14")) {
+                        data.listen = '    listen 443 ssl;\n' +
+                            '    listen [::]:443 ssl;';
                     } else {
                         data.listen = '    listen 443;' + '\n' +
+                            '    listen [::]:443;\n' +
                             '    ssl on;';
                     }
                     if (isOpenSSLSemVer(data.opensslVersion, ">=0.9.8f") && isSemVer(data.serverVersion, '>=1.5.9')) {


### PR DESCRIPTION
Hello, would the following changes be appropriate to include with the nginx generator?
- Always listen on both IPv4 and IPv6
- Enable HTTP/2 with nginx >=1.9.5
- Include an HTTP to HTTPS redirect when using HSTS

```
server {
    listen 80 default_server;
    listen [::]:80 default_server;

    # HSTS (ngx_http_headers_module is required) (15768000 seconds = 6 months)
    add_header Strict-Transport-Security max-age=15768000;

    # Redirect all HTTP requests to HTTPS with a 301 Moved Permanently response.
    return 301 https://$host$request_uri;
}

server {
    listen 443 ssl http2;
    listen [::]:443 ssl http2;
    [...]
}
```

On another note, with the public beta of LetsEncrypt.org, I'm curious if it would be appropriate to include an example of using the using the webroot certificate renewal:

```
server {
    listen 80 default_server;
    listen [::]:80 default_server;

    # HSTS (ngx_http_headers_module is required) (15768000 seconds = 6 months)
    add_header Strict-Transport-Security max-age=15768000;

    # LetsEncrypt.org TLS certificate renewal
    location ~ .well-known/acme-challenge/ {
        root /srv/letsencrypt;
    }

    # Redirect all HTTP requests to HTTPS with a 301 Moved Permanently response.
    location / {
        return 301 https://$host$request_uri;
    }
}
```

Finally, while I was reading how to configure nginx I didn't see too many examples that included headers such as in the [OWASP list of useful HTTP headers](https://www.owasp.org/index.php/List_of_useful_HTTP_headers). Should they be included in the generator or linked at the bottom of the page?
