### PR TITLE
Comment SSLCACertificateFile

### DIFF
--- a/ssl-config-generator/index.html
+++ b/ssl-config-generator/index.html
@@ -90,7 +90,9 @@ server {
     SSLEngine on
 {{certFile}}
     SSLCertificateKeyFile   /path/to/private/key
-    SSLCACertificateFile    /path/to/all_ca_certs
+
+    # Uncomment the following directive when using client certificate authentication
+    #SSLCACertificateFile    /path/to/ca_certs_for_client_authentication
 
 {{hsts}}
     ...


### PR DESCRIPTION
Fixes #132 

Note: this directive (add CA certificates for client authentication use) is only used in the Apache configuration, never in the other server software. Perhaps decide to delete it altogether?
