### PR TITLE
Update oldApache TLS support message

### DIFF
--- a/ssl-config-generator/index.html
+++ b/ssl-config-generator/index.html
@@ -310,7 +310,7 @@ $SERVER["socket"] == ":443" {
 
         var messageTypes = {
             oldOpenSSL: 'TLS v1.1 and v1.2 support is only present in OpenSSL 1.0.1 and newer',
-            oldApache: 'TLS v1.1 and v1.2 support is only present in Apache 2.4 and newer'
+            oldApache: 'TLS v1.1 and v1.2 support is only present in Apache 2.2.23 and newer'
         };
 
         $(function() {


### PR DESCRIPTION
Apache 2.2.23 and newer support TLS 1.1 and 1.2; update text to match commits from #81 
