### PR TITLE
use preferred haproxy header manipulation method

### DIFF
--- a/ssl-config-generator/index.html
+++ b/ssl-config-generator/index.html
@@ -391,7 +391,7 @@ $SERVER["socket"] == ":443" {
                     // http://www.haproxy.org/download/1.5/doc/configuration.txt
                     if (data.hstsEnabled == "true") {
                         data.hsts = '\n    # HSTS (15768000 seconds = 6 months)' + '\n' +
-                            '    rspadd  Strict-Transport-Security:\\ max-age=15768000';
+                            '    http-response set-header Strict-Transport-Security max-age=15768000';
                     }
                     if (isSemVer(data.serverVersion, "<1.5")) {
                         data.visibility = 'hidden';


### PR DESCRIPTION
Love this tool, but a minor nitpick on haproxy syntax used for setting the hsts max age. From the haproxy documentation:
"""
 Using "rspadd"/"rspdel"/"rsprep" to manipulate request headers is discouraged
  in newer versions (>= 1.5). But if you need to use regular expression to
  delete headers, you can still use "rspdel". Also please use
  "http-response deny" instead of "rspdeny".
"""

This actually doesn't mention a subtle but important difference in the syntax though: with 'rspadd' you will not get this setting if the client already set an hsts header. With 'http-response set-header' the server actually asserts the header is what the config says, even if the client were to say otherwise on every request.
