### PR TITLE
Remove client-side redirect now GitHub pages support enforcing HTTPS

### DIFF
--- a/ssl-config-generator/index.html
+++ b/ssl-config-generator/index.html
@@ -37,10 +37,6 @@
         // isSemVer says "1.0.1 > 1.0.1e" and isOpenSSLSemVer says "1.0.1 < 1.0.1e". isOpenSSLSemVer is needed to accommodate OpenSSL's version grammar
         var isOpenSSLSemVer=(function(){var a=/^(<|>|[=!<>]=)?\s*(\d+(?:\.\d+){0,2})([a-z][a-z0-9\-]*)?$/i;function b(e,c){var d=(e+"").match(a);return d?(c?(d[1]||"=="):"")+'"'+(d[2]+".0.0").match(/\d+(?:\.\d+){0,2}/)[0].replace(/(?:^|\.)(\d+)/g,function(g,f){return Array(9-f.length).join(0)+f;})+(d[3]||"")+'"':(c?"==0":1);}return function(e){e=b(e);for(var c,d=1;c=arguments[d++];){if(!(new Function("return "+e+b(c,1)))()){return false;}}return true;};})();
     </script>
-    <script>
-        if (window.location.protocol != "https:")
-            window.location.href = "https:" + window.location.href.substring(window.location.protocol.length);
-    </script>
 
     <script id="nginx-template" type="text/x-handlebars-template">
 <h2>{{server}} {{serverVersion}} | {{securityProfile}} profile | OpenSSL {{opensslVersion}} | <a href="?{{queryString}}">link</a></h2>


### PR DESCRIPTION
GitHub pages now support enforcing HTTPS (which has been enabled in #144), so the client-side redirect can now be removed. See:
https://help.github.com/articles/securing-your-github-pages-site-with-https/
