### PR TITLE
Add HSTS headers to Nginx error pages

### DIFF
--- a/ssl-config-generator/index.html
+++ b/ssl-config-generator/index.html
@@ -336,7 +336,7 @@ $SERVER["socket"] == ":443" {
                         data.hsts = '\n    # HSTS (ngx_http_headers_module is required) (15768000 seconds = 6 months)' + '\n' +
                             '    add_header Strict-Transport-Security "max-age=15768000"';
                         if (isSemVer(data.serverVersion, '>=1.7.5')) {
-                            data.hsts += ' always'
+                            data.hsts += ' always';
                         }
                         data.hsts += ';';
                     }

--- a/ssl-config-generator/index.html
+++ b/ssl-config-generator/index.html
@@ -334,7 +334,7 @@ $SERVER["socket"] == ":443" {
                     }
                     if (data.hstsEnabled == "true") {
                         data.hsts = '\n    # HSTS (ngx_http_headers_module is required) (15768000 seconds = 6 months)' + '\n' +
-                            '    add_header Strict-Transport-Security max-age=15768000;';
+                            '    add_header Strict-Transport-Security "max-age=15768000" always;';
                     }
                     if (isSemVer(data.serverVersion, ">=1.9.5")) {
                         data.listen = '    listen 443 ssl http2;\n' +

--- a/ssl-config-generator/index.html
+++ b/ssl-config-generator/index.html
@@ -334,7 +334,12 @@ $SERVER["socket"] == ":443" {
                     }
                     if (data.hstsEnabled == "true") {
                         data.hsts = '\n    # HSTS (ngx_http_headers_module is required) (15768000 seconds = 6 months)' + '\n' +
-                            '    add_header Strict-Transport-Security "max-age=15768000" always;';
+                            '    add_header Strict-Transport-Security "max-age=15768000"';
+                        if (isSemVer(data.serverVersion '>=1.7.5')) {
+                            data.hsts += ' always'
+                        }
+                        data.hsts += ';';
+                        
                     }
                     if (isSemVer(data.serverVersion, ">=1.9.5")) {
                         data.listen = '    listen 443 ssl http2;\n' +

--- a/ssl-config-generator/index.html
+++ b/ssl-config-generator/index.html
@@ -335,11 +335,10 @@ $SERVER["socket"] == ":443" {
                     if (data.hstsEnabled == "true") {
                         data.hsts = '\n    # HSTS (ngx_http_headers_module is required) (15768000 seconds = 6 months)' + '\n' +
                             '    add_header Strict-Transport-Security "max-age=15768000"';
-                        if (isSemVer(data.serverVersion '>=1.7.5')) {
+                        if (isSemVer(data.serverVersion, '>=1.7.5')) {
                             data.hsts += ' always'
                         }
                         data.hsts += ';';
-                        
                     }
                     if (isSemVer(data.serverVersion, ">=1.9.5")) {
                         data.listen = '    listen 443 ssl http2;\n' +


### PR DESCRIPTION
via http://nginx.org/en/docs/http/ngx_http_headers_module.html#add_header

```
Adds the specified field to a response header provided that the response code equals 200, 201, 204, 206, 301, 302, 303, 304, or 307. ...

If the always parameter is specified (1.7.5), the header field will be added regardless of the response code.
```

See also: http://serverfault.com/a/647552