### PR TITLE
Update default versions, httpd and openssl was EOL

### DIFF
--- a/ssl-config-generator/index.html
+++ b/ssl-config-generator/index.html
@@ -429,8 +429,8 @@ $SERVER["socket"] == ":443" {
             function loadFromQueryString() {
                 // http://stackoverflow.com/a/10834119/837015
                 var defaults = {
-                    "server": "apache-2.2.15",
-                    "openssl": "1.0.1e",
+                    "server": "apache-2.4.28",
+                    "openssl": "1.0.2l",
                     "hsts": "yes",
                     "profile": "intermediate"
                 };


### PR DESCRIPTION
It should perhaps be made somewhat simpler for people who are not running software which is EOL. With this change, the work of having to manually change versions of apache httpd and openssl is forced upon the people who run EOL software instead of people with up to date software.

Previous default version of apache httpd (2.2.15) is EOL since 2018/01/01 and no longer maintained. Previous default version of openssl (1.0.1e) is also no longer maintained (changed openssl to 1.0.2 which is LTS).

Sources:
https://httpd.apache.org/
https://www.openssl.org/policies/releasestrat.html