### PR TITLE
Use markdown link syntax.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Server Side TLS
 ===============
 
 Welcome to Mozilla's SSL/TLS Configuration Generator. For direct access to the
-generator, follow this link: https://mozilla.github.io/server-side-tls/ssl-config-generator/
+generator, follow this link: [SSL Configuration Generator](https://mozilla.github.io/server-side-tls/ssl-config-generator/).
 
 This repository also contains the mediawiki source for Mozilla's Server Side TLS
-document at https://wiki.mozilla.org/Security/Server_Side_TLS .
+document at [Server Side TLS](https://wiki.mozilla.org/Security/Server_Side_TLS).


### PR DESCRIPTION
Uses markdown link syntax to link the SSL Configuration Generator and Server Side TLS document.