### PR TITLE
Adds link to terraform module for AWS config

### DIFF
--- a/ssl-config-generator/index.html
+++ b/ssl-config-generator/index.html
@@ -140,7 +140,9 @@ frontend ft_test
   will create an <a href="https://aws.amazon.com/elasticloadbalancing/">Elastic Load Balancer</a> which
   terminates HTTPS connections using the Mozilla recommended ciphersuites and protocols.
 </p>
+<p>A third-party <a href="https://www.terraform.io/">Terraform</a> module with this configuration is available <a href="https://github.com/razorpay/terraform-aws-ssl-ciphers" title="terraform-aws-ssl-ciphers repository">here</a>.
 <pre style="visibility: {{visibility}};">
+</p>
 {{elbJson}}
 </pre>
     </script>


### PR DESCRIPTION
This was created out of a need because even the default ELB Configurations are not easily available in Terraform: https://github.com/terraform-providers/terraform-provider-aws/issues/1669

It supports all 3 mozilla configurations, and they are generated from the JSON files in this repo. Working on this was what led to #214 and #215 incidentally.