### PR TITLE
Fix link to JSON guidelines

### DIFF
--- a/json/README.md
+++ b/json/README.md
@@ -1,6 +1,6 @@
 # Current JSON Server Side TLS Recommendations
 
-The current JSON recommendations can be found at https://github.com/mozilla/ssl-config-generator/tree/master/docs/guidelines 
+The current JSON recommendations can be found at https://github.com/mozilla/ssl-config-generator/tree/master/src/static/guidelines
 
 # Historical JSON Versions of Server Side TLS Recommendations
 


### PR DESCRIPTION
I had pointed this to the `/docs` directory, but that's not the source. That's rendered from the `/src` directory. This commit corrects that