### PR TITLE
align color-coding with scoring/standard levels

### DIFF
--- a/Cipher_Suites.mediawiki
+++ b/Cipher_Suites.mediawiki
@@ -14,67 +14,67 @@ IANA, OpenSSL and GnuTLS use different naming for the same ciphers. The table be
 ! scope="col" | OpenSSL
 |-
 ! scope=row | 0x13,0x01
-| style="background-color: #9c0; font-weight: bold; text-align: center;" | 1
-| style="background-color: #9c0; font-weight: bold;" | TLS_AES_128_GCM_SHA256
-| style="background-color: #9c0; font-weight: bold;" | TLS_AES_128_GCM_SHA256
-| style="background-color: #9c0; font-weight: bold;" | TLS_AES_128_GCM_SHA256
-| style="background-color: #9c0; font-weight: bold;" | TLS_AES_128_GCM_SHA256
+| style="background-color: #99cc00; font-weight: bold; text-align: center;" | 1
+| style="background-color: #99cc00; font-weight: bold;" | TLS_AES_128_GCM_SHA256
+| style="background-color: #99cc00; font-weight: bold;" | TLS_AES_128_GCM_SHA256
+| style="background-color: #99cc00; font-weight: bold;" | TLS_AES_128_GCM_SHA256
+| style="background-color: #99cc00; font-weight: bold;" | TLS_AES_128_GCM_SHA256
 |-
 ! scope=row | 0x13,0x02
-| style="background-color: #9c0; font-weight: bold; text-align: center;" | 2
-| style="background-color: #9c0; font-weight: bold;" | TLS_AES_256_GCM_SHA384
-| style="background-color: #9c0; font-weight: bold;" | TLS_AES_256_GCM_SHA384
-| style="background-color: #9c0; font-weight: bold;" | TLS_AES_256_GCM_SHA384
-| style="background-color: #9c0; font-weight: bold;" | TLS_AES_256_GCM_SHA384
+| style="background-color: #99cc00; font-weight: bold; text-align: center;" | 2
+| style="background-color: #99cc00; font-weight: bold;" | TLS_AES_256_GCM_SHA384
+| style="background-color: #99cc00; font-weight: bold;" | TLS_AES_256_GCM_SHA384
+| style="background-color: #99cc00; font-weight: bold;" | TLS_AES_256_GCM_SHA384
+| style="background-color: #99cc00; font-weight: bold;" | TLS_AES_256_GCM_SHA384
 |-
 ! scope=row | 0x13,0x03
-| style="background-color: #9c0; font-weight: bold; text-align: center;" | 3
-| style="background-color: #9c0; font-weight: bold;" | TLS_CHACHA20_POLY1305_SHA256
-| style="background-color: #9c0; font-weight: bold;" | TLS_CHACHA20_POLY1305_SHA256
-| style="background-color: #9c0; font-weight: bold;" | TLS_CHACHA20_POLY1305_SHA256
-| style="background-color: #9c0; font-weight: bold;" | TLS_CHACHA20_POLY1305_SHA256
+| style="background-color: #99cc00; font-weight: bold; text-align: center;" | 3
+| style="background-color: #99cc00; font-weight: bold;" | TLS_CHACHA20_POLY1305_SHA256
+| style="background-color: #99cc00; font-weight: bold;" | TLS_CHACHA20_POLY1305_SHA256
+| style="background-color: #99cc00; font-weight: bold;" | TLS_CHACHA20_POLY1305_SHA256
+| style="background-color: #99cc00; font-weight: bold;" | TLS_CHACHA20_POLY1305_SHA256
 |-
 ! scope=row | 0xC0,0x2B
-| style="background-color: #fc6; font-weight: bold; text-align: center;" | 4
-| style="background-color: #fc6; font-weight: bold;" | TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-| style="background-color: #fc6; font-weight: bold;" | TLS_ECDHE_ECDSA_AES_128_GCM_SHA256
-| style="background-color: #fc6; font-weight: bold;" | TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-| style="background-color: #fc6; font-weight: bold;" | ECDHE-ECDSA-AES128-GCM-SHA256
+| style="background-color: #336699; font-weight: bold; text-align: center;" | 4
+| style="background-color: #336699; font-weight: bold;" | TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+| style="background-color: #336699; font-weight: bold;" | TLS_ECDHE_ECDSA_AES_128_GCM_SHA256
+| style="background-color: #336699; font-weight: bold;" | TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+| style="background-color: #336699; font-weight: bold;" | ECDHE-ECDSA-AES128-GCM-SHA256
 |-
 ! scope=row | 0xC0,0x2F
-| style="background-color: #fc6; font-weight: bold; text-align: center;" | 5
-| style="background-color: #fc6; font-weight: bold;" | TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-| style="background-color: #fc6; font-weight: bold;" | TLS_ECDHE_RSA_AES_128_GCM_SHA256
-| style="background-color: #fc6; font-weight: bold;" | TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-| style="background-color: #fc6; font-weight: bold;" | ECDHE-RSA-AES128-GCM-SHA256
+| style="background-color: #336699; font-weight: bold; text-align: center;" | 5
+| style="background-color: #336699; font-weight: bold;" | TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+| style="background-color: #336699; font-weight: bold;" | TLS_ECDHE_RSA_AES_128_GCM_SHA256
+| style="background-color: #336699; font-weight: bold;" | TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+| style="background-color: #336699; font-weight: bold;" | ECDHE-RSA-AES128-GCM-SHA256
 |-
 ! scope=row | 0xC0,0x2C
-| style="background-color: #fc6; font-weight: bold; text-align: center;" | 6
-| style="background-color: #fc6; font-weight: bold;" | TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
-| style="background-color: #fc6; font-weight: bold;" | TLS_ECDHE_ECDSA_AES_256_GCM_SHA384
-| style="background-color: #fc6; font-weight: bold;" | TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
-| style="background-color: #fc6; font-weight: bold;" | ECDHE-ECDSA-AES256-GCM-SHA384
+| style="background-color: #336699; font-weight: bold; text-align: center;" | 6
+| style="background-color: #336699; font-weight: bold;" | TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+| style="background-color: #336699; font-weight: bold;" | TLS_ECDHE_ECDSA_AES_256_GCM_SHA384
+| style="background-color: #336699; font-weight: bold;" | TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+| style="background-color: #336699; font-weight: bold;" | ECDHE-ECDSA-AES256-GCM-SHA384
 |-
 ! scope=row | 0xC0,0x30
-| style="background-color: #fc6; font-weight: bold; text-align: center;" | 7
-| style="background-color: #fc6; font-weight: bold;" | TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
-| style="background-color: #fc6; font-weight: bold;" | TLS_ECDHE_RSA_AES_256_GCM_SHA384
-| style="background-color: #fc6; font-weight: bold;" | TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
-| style="background-color: #fc6; font-weight: bold;" | ECDHE-RSA-AES256-GCM-SHA384
+| style="background-color: #336699; font-weight: bold; text-align: center;" | 7
+| style="background-color: #336699; font-weight: bold;" | TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+| style="background-color: #336699; font-weight: bold;" | TLS_ECDHE_RSA_AES_256_GCM_SHA384
+| style="background-color: #336699; font-weight: bold;" | TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+| style="background-color: #336699; font-weight: bold;" | ECDHE-RSA-AES256-GCM-SHA384
 |-
 ! scope=row | 0xCC,0xA9
-| style="background-color: #fc6; font-weight: bold; text-align: center;" | 8
-| style="background-color: #fc6; font-weight: bold;" | TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
-| style="background-color: #fc6; font-weight: bold;" | TLS_ECDHE_ECDSA_CHACHA20_POLY1305
-| style="background-color: #fc6; font-weight: bold;" | TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
-| style="background-color: #fc6; font-weight: bold;" | ECDHE-ECDSA-CHACHA20-POLY1305
+| style="background-color: #336699; font-weight: bold; text-align: center;" | 8
+| style="background-color: #336699; font-weight: bold;" | TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+| style="background-color: #336699; font-weight: bold;" | TLS_ECDHE_ECDSA_CHACHA20_POLY1305
+| style="background-color: #336699; font-weight: bold;" | TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+| style="background-color: #336699; font-weight: bold;" | ECDHE-ECDSA-CHACHA20-POLY1305
 |-
 ! scope=row | 0xCC,0xA8
-| style="background-color: #fc6; font-weight: bold; text-align: center;" | 9
-| style="background-color: #fc6; font-weight: bold;" | TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
-| style="background-color: #fc6; font-weight: bold;" | TLS_ECDHE_RSA_CHACHA20_POLY1305
-| style="background-color: #fc6; font-weight: bold;" | TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
-| style="background-color: #fc6; font-weight: bold;" | ECDHE-RSA-CHACHA20-POLY1305
+| style="background-color: #336699; font-weight: bold; text-align: center;" | 9
+| style="background-color: #336699; font-weight: bold;" | TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+| style="background-color: #336699; font-weight: bold;" | TLS_ECDHE_RSA_CHACHA20_POLY1305
+| style="background-color: #336699; font-weight: bold;" | TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+| style="background-color: #336699; font-weight: bold;" | ECDHE-RSA-CHACHA20-POLY1305
 |-
 ! scope=row | 0xD0,0x05
 | style="" data-sort-value="1000" | 


### PR DESCRIPTION
align color-coding with scoring/standard levels

x-ref:
  https://github.com/mozilla/server-side-tls/issues/297

github: fixes #297