### PR TITLE
Fix the Markdown links in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@ Server Side TLS
 ===============
 
 The Server Side TLS guidelines content has moved to two places
-* Mozilla's internal guidelines can be found on the Mozilla Confluence at https://mozilla-hub.atlassian.net/wiki/spaces/SECURITY/pages/2717548595/Server+Side+TLS+Recommended+Configurations
-* The public guidelines have been moved to a community working group managed project outside of Mozilla. The public guidelines can be found at https://docs.tlsref.org/ and the source code can be found at https://github.com/tlsref/docs
+* Mozilla's internal guidelines can be found on the [Mozilla Confluence page : Server Side TLS Recommended Configurations](https://mozilla-hub.atlassian.net/wiki/spaces/SECURITY/pages/2717548595/Server+Side+TLS+Recommended+Configurations)
+* The public guidelines have been moved to a community working group managed project outside of Mozilla. The public guidelines can be found at [https://docs.tlsref.org/](https://docs.tlsref.org/) and the source code can be found at [https://github.com/tlsref/docs](https://github.com/tlsref/docs)
 
 Historically, this repository contained both the MediaWiki source for Mozilla's Server Side TLS
 document at [Server Side TLS](https://wiki.mozilla.org/Security/Server_Side_TLS) and Mozilla's SSL/TLS Configuration Generator. Access the current generator by following this link: [TLSRef TLS Configuration Generator](https://configurator.tlsref.org/).
-The current code for the configuration generator is located at https://github.com/tlsref/configurator , the previous code was located at https://github.com/mozilla/ssl-config-generator and the original code from years before that [can be found at this revision](https://github.com/mozilla/server-side-tls/tree/last-revision-before-move).
+The current code for the configuration generator is located at [https://github.com/tlsref/configurator](https://github.com/tlsref/configurator), the previous code was located at [https://github.com/mozilla/ssl-config-generator](https://github.com/mozilla/ssl-config-generator) and the original code from years before that [can be found at this revision](https://github.com/mozilla/server-side-tls/tree/last-revision-before-move).


### PR DESCRIPTION
The GitHub pages renderer for Markdown doesn't convert URLs to links, this works around that.